### PR TITLE
Change module structure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,29 +12,13 @@ struct BindGenCallback;
 impl ParseCallbacks for BindGenCallback {
     fn item_name(&self, original_item_name: &str) -> Option<String> {
         if original_item_name == "in6_addr" {
-            Some(
-                original_item_name
-                    .replace("in6_addr", "libc::in6_addr")
-                    .to_string(),
-            )
+            Some(original_item_name.replace("in6_addr", "libc::in6_addr"))
         } else if original_item_name.starts_with("pthread_") {
-            Some(
-                original_item_name
-                    .replace("pthread_", "libc::pthread_")
-                    .to_string(),
-            )
+            Some(original_item_name.replace("pthread_", "libc::pthread_"))
         } else if original_item_name.starts_with("sockaddr") {
-            Some(
-                original_item_name
-                    .replace("sockaddr", "libc::sockaddr")
-                    .to_string(),
-            )
+            Some(original_item_name.replace("sockaddr", "libc::sockaddr"))
         } else if original_item_name == "timespec" {
-            Some(
-                original_item_name
-                    .replace("timespec", "libc::timespec")
-                    .to_string(),
-            )
+            Some(original_item_name.replace("timespec", "libc::timespec"))
         } else {
             None
         }
@@ -53,19 +37,13 @@ fn main() {
         .atleast_version(LIB_IBVERBS_DEV_VERSION)
         .statik(true)
         .probe("libibverbs")
-        .expect(&format!(
-            "please install libibverbs-dev {}",
-            LIB_IBVERBS_DEV_VERSION
-        ));
+        .unwrap_or_else(|_| panic!("please install libibverbs-dev {}", LIB_IBVERBS_DEV_VERSION));
 
     pkg_config::Config::new()
         .atleast_version(LIB_RDMACM_DEV_VERSION)
         .statik(true)
         .probe("librdmacm")
-        .expect(&format!(
-            "please install librdmacm-dev {}",
-            LIB_RDMACM_DEV_VERSION,
-        ));
+        .unwrap_or_else(|_| panic!("please install librdmacm-dev {}", LIB_RDMACM_DEV_VERSION));
 
     let bindings = bindgen::Builder::default()
         .header("/usr/include/infiniband/verbs.h")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,23 @@
 #![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![allow(deref_nullptr)] // TODO(fxbug.dev/74605): Remove once bindgen is fixed.
+#![allow(
+    clippy::missing_safety_doc,
+    clippy::needless_return,
+    clippy::too_many_arguments,
+    clippy::cmp_null
+)]
 
-pub mod verbs;
-pub use verbs::*;
+mod bindings {
+    use crate::*;
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+mod types;
+mod verbs;
+
+use std::os::raw::{c_int, c_uint, c_void};
+
+pub use self::bindings::*;
+pub use self::types::*;
+pub use self::verbs::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,7 @@
 #![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![allow(deref_nullptr)] // TODO(fxbug.dev/74605): Remove once bindgen is fixed.
-#![allow(
-    clippy::missing_safety_doc,
-    clippy::needless_return,
-    clippy::too_many_arguments,
-    clippy::cmp_null
-)]
+#![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
 
 mod bindings {
     use crate::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
+use crate::*;
+
 /// This file defines the types directly or indirectly involving union,
 /// in that BindGen cannot handle union very well, so mannually define them.
-
 
 /// Struct types involve union in <infiniband/verbs.h>
 
@@ -181,11 +182,11 @@ pub struct tm_t {
 
 #[repr(C)]
 pub struct ibv_ops_wr {
-	wr_id: u64,
-	next: *mut Self,
-	opcode: ibv_ops_wr_opcode::Type,
-	flags: c_int,
-	tm: tm_t,
+    wr_id: u64,
+    next: *mut Self,
+    opcode: ibv_ops_wr_opcode::Type,
+    flags: c_int,
+    tm: tm_t,
 }
 
 // ibv_flow_spec related union and struct types

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1,9 +1,7 @@
-use std::mem;
-use std::os::raw::{c_int, c_uint, c_void};
-use std::ptr;
+use crate::*;
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-include!("./types.rs");
+use std::mem;
+use std::ptr;
 
 /// Inline functions from <infiniband/verbs.h>
 

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -935,7 +935,7 @@ pub unsafe fn ibv_post_send(
     wr: *mut ibv_send_wr,
     bad_wr: *mut *mut ibv_send_wr,
 ) -> c_int {
-    return (*(*qp).context).ops.post_send.unwrap()(qp, wr, bad_wr);
+    (*(*qp).context).ops.post_send.unwrap()(qp, wr, bad_wr)
 }
 
 #[inline]
@@ -944,7 +944,7 @@ pub unsafe fn ibv_post_recv(
     wr: *mut ibv_recv_wr,
     bad_wr: *mut *mut ibv_recv_wr,
 ) -> c_int {
-    return (*(*qp).context).ops.post_recv.unwrap()(qp, wr, bad_wr);
+    (*(*qp).context).ops.post_recv.unwrap()(qp, wr, bad_wr)
 }
 
 #[inline]
@@ -1148,7 +1148,7 @@ pub unsafe fn rdma_post_readv(
     };
     let mut bad = ptr::null::<ibv_send_wr>() as *mut _;
 
-    return rdma_seterrno(ibv_post_send((*id).qp, &mut wr, &mut bad));
+    rdma_seterrno(ibv_post_send((*id).qp, &mut wr, &mut bad))
 }
 
 #[inline]
@@ -1211,11 +1211,7 @@ pub unsafe fn rdma_post_send(
     let mut sge = ibv_sge {
         addr: addr as u64,
         length: length as u32,
-        lkey: if mr as *const _ != ptr::null::<ibv_mr>() {
-            (*mr).lkey
-        } else {
-            0
-        },
+        lkey: if !mr.is_null() { (*mr).lkey } else { 0 },
     };
     let nsge = 1;
     rdma_post_sendv(id, context, &mut sge, nsge, flags)
@@ -1255,11 +1251,7 @@ pub unsafe fn rdma_post_write(
     let mut sge = ibv_sge {
         addr: addr as u64,
         length: length as u32,
-        lkey: if mr as *const _ != ptr::null::<ibv_mr>() {
-            (*mr).lkey
-        } else {
-            0
-        },
+        lkey: if !mr.is_null() { (*mr).lkey } else { 0 },
     };
     let nsge = 1;
     rdma_post_writev(id, context, &mut sge, nsge, flags, remote_addr, rkey)
@@ -1279,11 +1271,7 @@ pub unsafe fn rdma_post_ud_send(
     let mut sge = ibv_sge {
         addr: addr as u64,
         length: length as u32,
-        lkey: if mr as *const _ != ptr::null::<ibv_mr>() {
-            (*mr).lkey
-        } else {
-            0
-        },
+        lkey: if !mr.is_null() { (*mr).lkey } else { 0 },
     };
 
     let mut wr = std::mem::zeroed::<ibv_send_wr>();
@@ -1295,7 +1283,7 @@ pub unsafe fn rdma_post_ud_send(
     wr.send_flags = flags as c_uint;
     wr.wr = wr_t {
         ud: ud_t {
-            ah: ah,
+            ah,
             remote_qpn,
             remote_qkey: RDMA_UDP_QKEY,
         },


### PR DESCRIPTION
rust-analyzer cannot jump to the sys definitons from [async-rdma](https://github.com/datenlord/async-rdma) codebase.
To fix the problem, we need to change the module structure in rdma-sys.