### PR TITLE
Allow custom rdma-core installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   schedule: [cron: "0 */24 * * *"]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.56.0
+  CI_RUST_TOOLCHAIN: 1.61.0
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rdma-sys"
 version = "0.1.0"
 authors = ["Pu Wang <nicolas.weeks@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Rdma ibverbs lib Rust binding"
 license-file = "LICENSE"
 repository = "https://github.com/datenlord/rdma-sys"

--- a/build.rs
+++ b/build.rs
@@ -1,25 +1,5 @@
-use bindgen::callbacks::ParseCallbacks;
 use std::env;
 use std::path::Path;
-
-#[derive(Debug)]
-struct BindGenCallback;
-
-impl ParseCallbacks for BindGenCallback {
-    fn item_name(&self, original_item_name: &str) -> Option<String> {
-        if original_item_name == "in6_addr" {
-            Some(original_item_name.replace("in6_addr", "libc::in6_addr"))
-        } else if original_item_name.starts_with("pthread_") {
-            Some(original_item_name.replace("pthread_", "libc::pthread_"))
-        } else if original_item_name.starts_with("sockaddr") {
-            Some(original_item_name.replace("sockaddr", "libc::sockaddr"))
-        } else if original_item_name == "timespec" {
-            Some(original_item_name.replace("timespec", "libc::timespec"))
-        } else {
-            None
-        }
-    }
-}
 
 fn link_rdma_core(lib_name: &str, pkg_name: &str, version: &str, include_paths: &mut Vec<String>) {
     let result: _ = pkg_config::Config::new()
@@ -168,7 +148,6 @@ fn main() {
         .rustfmt_bindings(true)
         .size_t_is_usize(true)
         .disable_untagged_union()
-        .parse_callbacks(Box::new(BindGenCallback))
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -1,0 +1,3 @@
+#include <infiniband/verbs.h>
+#include <rdma/rdma_cma.h>
+#include <rdma/rdma_verbs.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,12 @@
 #![allow(deref_nullptr)] // TODO(fxbug.dev/74605): Remove once bindgen is fixed.
 #![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
 
-mod bindings {
-    use crate::*;
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-}
+use libc::*;
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 mod types;
 mod verbs;
 
-use std::os::raw::{c_int, c_uint, c_void};
-
-pub use self::bindings::*;
 pub use self::types::*;
 pub use self::verbs::*;


### PR DESCRIPTION
1. bump ci rust toolchain to 1.61.0
2. set rust edtion to 2021
3. find include paths from pkg-config
4. dynamic link rdma-core (resolves #16 )
5. remove the commented code since we don't need it actually
6. replace the parse callback with a wildcard import of libc