### PR TITLE
change `ibv_evnet_type` from u32 to rust enum.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -117,7 +117,6 @@ fn main() {
         .constified_enum_module("ibv_atomic_cap")
         .constified_enum_module("ibv_mtu")
         .constified_enum_module("ibv_port_state")
-        .constified_enum_module("ibv_event_type")
         .constified_enum_module("ibv_wc_status")
         .constified_enum_module("ibv_wc_opcode")
         .constified_enum_module("ibv_mw_type")
@@ -138,6 +137,7 @@ fn main() {
         .constified_enum_module("rdma_cm_event_type")
         .constified_enum_module("rdma_driver_id")
         .constified_enum_module("rdma_port_space")
+        .rustified_enum("ibv_event_type")
         // unions with non-`Copy` fields other than `ManuallyDrop<T>` are unstable
         // for example: `pub eth: ibv_flow_spec_eth`
         // note: see issue #55149 <https://github.com/rust-lang/rust/issues/55149> for more information

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,7 +33,7 @@ pub union ibv_async_event_element_t {
 #[repr(C)]
 pub struct ibv_async_event {
     pub element: ibv_async_event_element_t,
-    pub event_type: ibv_event_type::Type,
+    pub event_type: ibv_event_type,
 }
 
 // ibv_wc related union and struct types


### PR DESCRIPTION
Rust enum is more convenient to use.