### PR TITLE
update bindgen to fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/datenlord/rdma-sys"
 
 [dependencies]
 libc = "0.2"
-memoffset = "0.6"
+memoffset = "0.9"
 paste = "1.0"
 # intrusive-collections = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ paste = "1.0"
 # intrusive-collections = "0.9"
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.70.1"
 pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
+use bindgen::Formatter;
 use std::env;
 use std::path::Path;
-use bindgen::Formatter;
 
 fn link_rdma_core(lib_name: &str, pkg_name: &str, version: &str, include_paths: &mut Vec<String>) {
     let result: _ = pkg_config::Config::new()

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::Path;
+use bindgen::Formatter;
 
 fn link_rdma_core(lib_name: &str, pkg_name: &str, version: &str, include_paths: &mut Vec<String>) {
     let result: _ = pkg_config::Config::new()
@@ -148,7 +149,7 @@ fn main() {
         //.generate_inline_functions(true)
         //.default_macro_constant_type(bindgen::MacroTypeVariation::Unsigned)
         .prepend_enum_name(false)
-        .rustfmt_bindings(true)
+        .formatter(Formatter::Rustfmt)
         .size_t_is_usize(true)
         .disable_untagged_union()
         .generate()


### PR DESCRIPTION
This pull request updates the bindgen crate to the latest version, addressing build issue #26 with minimal changes to the codebase.

Additionally, the memoffset crate is also updated as part of this PR for consistency.